### PR TITLE
change logic for architecture detection

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,29 @@ get_binary_path_in_archive() {
 }
 
 get_platform() {
-  echo "$(uname)_x86_64"
+  # echo "$(uname)_x86_64"
+
+  local machine_hardware_name
+  machine_hardware_name=${ASDF_KUBECTL_OVERWRITE_ARCH:-"$(uname -m)"}
+  version_short=$(echo ${version}|sed -e 's/^v//')
+  version_split=( ${version_short//./ } )
+  case "$machine_hardware_name" in
+    'x86_64') local cpu_type="amd64" ;;
+    'aarch64') local cpu_type="arm64" ;;
+    # 'armv7l') local cpu_type="armv7" ;;
+    *) local cpu_type="$machine_hardware_name" ;;
+  esac
+
+  # Work around arch type on filenames after 0.11.2
+  if [ "${cpu_type}" == "amd64" ] && [ ${version_split[0]} -eq 0 ] && [ ${version_split[1]} -le 11 ]; then
+     cpu_type="x86_64"
+     if [ ${version_split[1]} -eq 11 ] && [ ${version_split[2]} -gt 1  ]; then
+        cpu_type="amd64"
+     fi
+  fi
+
+  echo "$(uname)_${cpu_type}"
+
 }
 
 get_filename() {


### PR DESCRIPTION
as stated in https://github.com/nlamirault/asdf-popeye/issues/3 the architecure used in filenames changed from x86_64 to amd64, so the plugin needs a filter for that.

I took the opportunity to include other archs as well, inspiring myself with the asdf-kubectl plugin, adding the tests cases for amd64. It's not the greatest code I've written so far, so feel free to try to propose enhancements :)