### PR TITLE
Fix install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -68,7 +68,21 @@ get_platform() {
      fi
   fi
 
-  echo "$(uname)_${cpu_type}"
+  # Workaround platform in filenames after v0.20.5
+  local platform
+  local _lowercase_platform
+  _lowercase_platform="$(uname|tr '[:upper:]' '[:lower:]')"
+  if [ ${version_split[0]} -gt 0 ]; then
+    platform=$_lowercase_platform
+  elif [ ${version_split[0]} -eq 0 ] && [ ${version_split[1]} -gt 20 ]; then
+    platform=$_lowercase_platform
+  elif [ ${version_split[0]} -eq 0 ] && [ ${version_split[1]} -eq 20 ] && [ ${version_split[2]} -gt 5 ]; then
+    platform=$_lowercase_platform
+  else
+    platform="$(uname)"
+  fi
+
+  echo "${platform}_${cpu_type}"
 
 }
 
@@ -91,7 +105,7 @@ get_download_url() {
   local filename
   filename="$(get_filename "$version" "$platform" "$binary_name")"
 
-  echo "https://github.com/derailed/popeye/releases/download/${version}/${filename}"
+  echo "https://github.com/derailed/popeye/releases/download/v${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -16,6 +16,6 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed -e 's/tag_name\": *\"//;s/\",//' -e 's/^v//' | sort_versions)
 # shellcheck disable=SC2086
 echo $versions


### PR DESCRIPTION
* remove leading "v" from version in "list-all" output
* handle upstream "popeye" platform naming by ensuring lowercase name after v0.20.5

fixes #8